### PR TITLE
Fixed NUL chars being added when adding telemetry domains to hosts file

### DIFF
--- a/scripts/disable-telemetry.ps1
+++ b/scripts/disable-telemetry.ps1
@@ -1,6 +1,6 @@
 #   Description:
 # This script redirects telemetry related domains to your nowhere using the
-# hosts file. Telemtry realted ips are blocked by Windows firewall.
+# hosts file. Hard coded telemetry related IPs are blocked by Windows firewall.
 # Additionally telemetry is disallows via Group Policies.
 
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\reg-helper.psm1
@@ -14,7 +14,7 @@ foreach ($h in $hosts) {
         $ips += [ipaddress]$h
     } catch [System.InvalidCastException] {
         # can be redirected by hosts
-        echo "0.0.0.0 $h" >> "$env:systemroot\System32\drivers\etc\hosts"
+        echo "0.0.0.0 $h" | Out-File -Encoding ASCII -Append "$env:systemroot\System32\drivers\etc\hosts"
     }
 }
 

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -34,6 +34,11 @@ $apps = @(
     "Microsoft.ZuneMusic"
     "Microsoft.ZuneVideo"
     "microsoft.windowscommunicationsapps"
+    "Microsoft.MinecraftUWP"
+    "Flipboard.Flipboard"
+    "9E2F88E3.Twitter"
+    "king.com.CandyCrushSaga"
+    "ShazamEntertainmentLtd.Shazam"
 )
 
 foreach ($app in $apps) {


### PR DESCRIPTION
Also remove additional installed apps that come with the upgrade from 8.1. 

Tested on Windows 10 Home (x64).