### PR TITLE
Update scripts for Threshold 2 / version 1511

### DIFF
--- a/scripts/disable-windows-features.ps1
+++ b/scripts/disable-windows-features.ps1
@@ -18,6 +18,9 @@ sp "HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows Defender" "DisableRout
 mkdir -Force "HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows Defender\Real-Time Protection"
 sp "HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows Defender\Real-Time Protection" "DisableRealtimeMonitoring" 1
 
+echo "Removing Windows Defender context menu item"
+si "HKLM:\SOFTWARE\Classes\CLSID\{09A47860-11B0-4DA5-AFA5-26D86198A780}\InprocServer32" ""
+
 echo "Disable Notification Center"
 sp "HKLM:\Software\Microsoft\Windows\CurrentVersion\ImmersiveShell" UseActionCenterExperience 0
 

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -36,6 +36,12 @@ $apps = @(
     "microsoft.windowscommunicationsapps"
     "Microsoft.MinecraftUWP"
 
+    # Threshold 2 apps
+    "Microsoft.CommsPhone"
+    "Microsoft.ConnectivityStore"
+    "Microsoft.Messaging"
+    "Microsoft.Office.Sway"
+
     # non-Microsoft
     "9E2F88E3.Twitter"
     "Flipboard.Flipboard"

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -82,7 +82,7 @@ $needles = @(
     #"Maps"
     "OneDrive"
     #"Wallet"
-    "Xbox"
+    #"Xbox"
 )
 
 foreach ($needle in $needles) {


### PR DESCRIPTION
- Added new apps to the removal script
- Removed Xbox force remove, changing that package group puts system in bootloop
- Removed Windows Defender context menu item when Defender is disabled