### PR TITLE
add ProviderName flag when installing packages

### DIFF
--- a/utils/install-basic-software.ps1
+++ b/utils/install-basic-software.ps1
@@ -33,7 +33,7 @@ echo "Setting up Chocolatey software package manager"
 Get-PackageProvider -Name chocolatey -Force
 
 echo "Installing Packages"
-Install-Package -Name $packages -Force
+Install-Package -Name $packages -Force -ProviderName chocolatey
 
 echo "Installing Sysinternals Utilities to C:\Sysinternals"
 $download_uri = "https://download.sysinternals.com/files/SysinternalsSuite.zip"


### PR DESCRIPTION
Tried running the file to install putty and got this:

WARNING: 'putty' matched package 'putty/0.67' from provider: 'Chocolatey', source 'chocolatey'
WARNING: 'Putty' matched package 'Putty/1.0' from provider: 'PowerShellGet', source 'PSGallery'
Install-Package : Unable to install, multiple packages matched 'Putty'. Please specify a single -ProviderName.

Following the surprisingly helpful error message, I added the ProviderName flag to the end of line 36

Testing on my system and all seems fine.