### PR TITLE
Added Pandora to unwanted app list.

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -54,6 +54,7 @@ $apps = @(
 
     # non-Microsoft
     "9E2F88E3.Twitter"
+    "PandoraMediaInc.29680B314EFC2"
     "Flipboard.Flipboard"
     "ShazamEntertainmentLtd.Shazam"
     "king.com.CandyCrushSaga"


### PR DESCRIPTION
After running the script on several fresh installs of Windows 10 Anniversary I've noticed Pandora is always left behind, just sitting there pinned to the start menu.

> Name                   : PandoraMediaInc.29680B314EFC2`
Publisher              : CN=22480B76-7159-4685-A216-29BAB2C298BD
Architecture           : X64
ResourceId             :
Version                : 10.0.7.0
PackageFullName        : PandoraMediaInc.29680B314EFC2_10.0.7.0_x64__n619g4d5j0fnw
InstallLocation        : C:\Program Files\WindowsApps\PandoraMediaInc.29680B314EFC2_10.0.7.0_x64__n619g4d5j0fnw
IsFramework            : False
PackageFamilyName      : PandoraMediaInc.29680B314EFC2_n619g4d5j0fnw
PublisherId            : n619g4d5j0fnw
PackageUserInformation : {S-1-5-21-2883809385-464210202-4109797686-1001 [BW]: Installed}
IsResourcePackage      : False
IsBundle               : False
IsDevelopmentMode      : False
Dependencies           : {PandoraMediaInc.29680B314EFC2_10.0.7.0_neutral_split.scale-100_n619g4d5j0fnw}