### PR TITLE
Update remove-default-apps.ps1

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -94,3 +94,6 @@ foreach ($app in $apps) {
         where DisplayName -EQ $app |
         Remove-AppxProvisionedPackage -Online
 }
+
+# Unpin all remaining tiles from Start Menu
+((New-Object -Com Shell.Application).NameSpace('shell:::{4234d49b-0245-4df3-b780-3893943456e1}').Items() | ?{$_.Name}).Verbs() | ?{$_.Name.replace('&','') -match 'From "Start" UnPin|Unpin from Start'} | %{$_.DoIt()}


### PR DESCRIPTION
After removing desired apps, the following change will unpin any remaining tiles from the default Start Menu.