### PR TITLE
Add apps from creators update

### DIFF
--- a/scripts/experimental_unfuckery.ps1
+++ b/scripts/experimental_unfuckery.ps1
@@ -19,9 +19,12 @@ $needles = @(
     "Feedback"
     "Flash"
     "Gaming"
+    #"Holo"
     #"InternetExplorer"
     #"Maps"
+    #"MiracastView"
     "OneDrive"
+    #"SecHealthUI"
     #"Wallet"
     #"Xbox"          # This will result in a bootloop since upgrade 1511
 )

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -48,6 +48,9 @@ $apps = @(
     "Microsoft.OneConnect"
     "Microsoft.WindowsFeedbackHub"
 
+    # Creators Update apps
+    "Microsoft.Microsoft3DViewer"
+    #"Microsoft.MSPaint"
 
     #Redstone apps
     "Microsoft.BingFoodAndDrink"


### PR DESCRIPTION
Adding few apps that are included in the Creators update. There were more of them but I already removed many by hand. 

All of the mixed reality / HoloLens related apps are system apps and can't be removed by user. Same for the Miracast View and the new Security Health app. I added these to the experimental script and did not even try to remove them.