### PR TITLE
Taskbar defaults

### DIFF
--- a/scripts/optimize-user-interface.ps1
+++ b/scripts/optimize-user-interface.ps1
@@ -82,6 +82,10 @@ rm "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyCompu
 echo "Default taskbar settings"
 # Show taskbar labels (combine only when taskbar is full)"
 sp "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "TaskbarGlomLevel" "1"
+sp "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "MMTaskbarGlomLevel" "1"
+# Show taskbar buttons on taskbar where window is open (multiple displays)"
+sp "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "MMTaskbarMode" "2"
+
 #echo "Disabling tile push notification"
 #force-mkdir "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications"
 #sp "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" "NoTileApplicationNotification" 1

--- a/scripts/optimize-user-interface.ps1
+++ b/scripts/optimize-user-interface.ps1
@@ -79,6 +79,9 @@ rm "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpac
 rm "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{A0953C92-50DC-43bf-BE83-3742FED03C9C}"
 rm "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{f86fa3ab-70d2-4fc7-9c99-fcbf05467f3a}"
 
+echo "Default taskbar settings"
+# Show taskbar labels (combine only when taskbar is full)"
+sp "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "TaskbarGlomLevel" "1"
 #echo "Disabling tile push notification"
 #force-mkdir "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications"
 #sp "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" "NoTileApplicationNotification" 1

--- a/scripts/optimize-user-interface.ps1
+++ b/scripts/optimize-user-interface.ps1
@@ -89,3 +89,6 @@ sp "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "MMTaskba
 #echo "Disabling tile push notification"
 #force-mkdir "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications"
 #sp "HKCU:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" "NoTileApplicationNotification" 1
+
+# Restart explorer
+Get-Process -Name explorer | Stop-Process


### PR DESCRIPTION
Thanks for these scripts, saved me a lot of time! Here are some additions, which I think are quite useful for many people, tho I can't assume their setup, there isn't really any disadvantage at all. So basically all it does is to **show the taskbar labels** we all got used to from previous windows versions. There is enough space and I see no reason not to use them. In a multi-monitor setup, **the window will only appear in the taskbar of the current screen**, instead of sharing them across all the screens. I guess this will suit most use cases.