### PR TITLE
disable memory-compression

### DIFF
--- a/utils/disable-memory-compression
+++ b/utils/disable-memory-compression
@@ -1,0 +1,3 @@
+@echo off
+
+Disable-MMAgent -mc


### PR DESCRIPTION
Windows 10 came with this new feature, but in some cases this may causes some crashes and slowdown the OS.