### PR TITLE
Remove OneDrive scheduled task

### DIFF
--- a/scripts/remove-onedrive.ps1
+++ b/scripts/remove-onedrive.ps1
@@ -42,6 +42,9 @@ reg unload "hku\Default"
 echo "Removing startmenu entry"
 rm -Force -ErrorAction SilentlyContinue "$env:userprofile\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OneDrive.lnk"
 
+echo "Removing scheduled task"
+Get-ScheduledTask -TaskPath '\' -TaskName 'OneDrive*' -ea SilentlyContinue | Unregister-ScheduledTask -Confirm:$false
+
 echo "Restarting explorer"
 start "explorer.exe"
 


### PR DESCRIPTION
After running 'remove-onedrive.ps1' recently, I noticed a left over OneDrive scheduled task on my system.

This should silently remove it, if it's present or not.