### PR TITLE
remove apps for AllUsers

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -101,7 +101,7 @@ $apps = @(
 foreach ($app in $apps) {
     Write-Output "Trying to remove $app"
 
-    Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage
+    Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage -AllUsers
 
     Get-AppXProvisionedPackage -Online |
         Where-Object DisplayName -EQ $app |


### PR DESCRIPTION
See Issue #131 

> As of v1709 (Fall Creator's Update), there is a new "-AllUsers" flag for Remove-AppxPackage

from
https://social.technet.microsoft.com/Forums/en-US/1d096aa8-924b-484a-ae92-7757e3029198/powershell-script-to-remove-apps-doesnt-work-for-all-users?forum=win10itprosetup

docs
https://docs.microsoft.com/en-us/powershell/module/appx/remove-appxpackage?view=win10-ps

Related #64 

Actually, I just did `Remove-AppxPackage -?` to check the help file on the normal Creators Update 1703, and I see the `-AllUsers` switch also. So that comment from msdn is not correct. Can someone verify for previous versions of Win10?