### PR TITLE
Disable Aero-Shake feature

### DIFF
--- a/scripts/optimize-user-interface.ps1
+++ b/scripts/optimize-user-interface.ps1
@@ -46,6 +46,9 @@ Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advan
 Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "HideDrivesWithNoMedia" 0
 Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "ShowSyncProviderNotifications" 0
 
+Write-Output "Disable Aero-Shake Minimize feature"
+Set-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "DisallowShaking" 1
+
 Write-Output "Setting default explorer view to This PC"
 Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "LaunchTo" 1
 


### PR DESCRIPTION
Disable the Aero-Shake feature which minimizes all windows when you shake mouse while holding window.
Added lines to "Optimize-user-interface.ps1" that create Registry key 
"HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "DisallowShaking" 1