### PR TITLE
New script - disable_cortana.ps1

### DIFF
--- a/scripts/disable_cortana.ps1
+++ b/scripts/disable_cortana.ps1
@@ -1,3 +1,9 @@
+#   Description:
+# This script disables Cortana while still preserving the ability to use the Start Menu for search
+
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\take-own.psm1
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\force-mkdir.psm1
+
 
 # http://www.thewindowsclub.com/disable-turn-off-cortana-windows-10
 force-mkdir "HKLM:\SOFTWARE\Microsoft\Windows\Windows Search"

--- a/scripts/disable_cortana.ps1
+++ b/scripts/disable_cortana.ps1
@@ -1,0 +1,6 @@
+
+# http://www.thewindowsclub.com/disable-turn-off-cortana-windows-10
+force-mkdir "HKLM:\SOFTWARE\Microsoft\Windows\Windows Search"
+Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\Windows Search" "AllowCortana" 0
+force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search"
+Set-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" "AllowCortana" 0

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -13,6 +13,7 @@ $apps = @(
     # default Windows 10 apps
     "Microsoft.3DBuilder"
     "Microsoft.Appconnector"
+    "Microsoft.Advertising.Xaml" 
     "Microsoft.BingFinance"
     "Microsoft.BingNews"
     "Microsoft.BingSports"
@@ -42,7 +43,7 @@ $apps = @(
     "Microsoft.WindowsSoundRecorder"
     #"Microsoft.WindowsStore"
     "Microsoft.XboxApp"
-	"Microsoft.XboxGameOverlay"
+    "Microsoft.XboxGameOverlay"
     "Microsoft.XboxIdentityProvider"
     "Microsoft.XboxSpeechToTextOverlay"
     "Microsoft.ZuneMusic"
@@ -103,7 +104,8 @@ $apps = @(
     "SpotifyAB.SpotifyMusic"
     "A278AB0D.DisneyMagicKingdoms"
     "WinZipComputing.WinZipUniversal"
-
+    "CAF9E577.Plex"  
+    "7EE7776C.LinkedInforWindows"
 
     # apps which cannot be removed using Remove-AppxPackage
     #"Microsoft.BioEnrollment"

--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -127,6 +127,27 @@ foreach ($app in $apps) {
         Remove-AppxProvisionedPackage -Online
 }
 
+
+# Prevents Apps from re-installing
+# TODO - see if we need to do `force-mkdir` for any of these paths
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "FeatureManagementEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "OemPreInstalledAppsEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "PreInstalledAppsEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SilentInstalledAppsEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "ContentDeliveryAllowed" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "PreInstalledAppsEverEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContentEnabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338388Enabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338389Enabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-314559Enabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338387Enabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338393Enabled" 0
+Set-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SystemPaneSuggestionsEnabled" 0
+
+force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore"
+Set-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore" "AutoDownload" 2
+
 # Prevents "Suggested Applications" returning
 force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Cloud Content"
 Set-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Cloud Content" "DisableWindowsConsumerFeatures" 1
+


### PR DESCRIPTION
Not sure if this should be in the privacy settings script, but this reg key disables Cortana. Apparently Task manager will say Cortana is still running after doing this, but it's really just SearchUI.exe.

https://www.howtogeek.com/271096/why-is-cortana-still-running-in-the-background-after-you-disable-it/

EDIT: Meant to have just this script in this PR, but it pulled in my commits from #168 too. I'll resubmit.