### PR TITLE
Disable Windows Network Data Usage Monitor Service

### DIFF
--- a/scripts/disable-services.ps1
+++ b/scripts/disable-services.ps1
@@ -23,7 +23,7 @@ $services = @(
     "XblAuthManager"                           # Xbox Live Auth Manager
     "XblGameSave"                              # Xbox Live Game Save Service
     "XboxNetApiSvc"                            # Xbox Live Networking Service
-
+    "ndu"                                      # Windows Network Data Usage Monitor
     # Services which cannot be disabled
     #"WdNisSvc"
 )


### PR DESCRIPTION
See commit notes, this service isn't needed for most desktops/laptops and disabling it gives a performance boost.