### PR TITLE
Removing YourPhone application

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -47,6 +47,7 @@ $apps = @(
     "Microsoft.XboxGameOverlay"
     "Microsoft.XboxGamingOverlay"
     "Microsoft.XboxSpeechToTextOverlay"
+    "Microsoft.YourPhone"
     "Microsoft.ZuneMusic"
     "Microsoft.ZuneVideo"
 


### PR DESCRIPTION
The `Microsoft.YourPhone` is installed by default. It's specs are:

```
Name              : Microsoft.YourPhone                                                                                 
Publisher         : CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US                    
Architecture      : X64                                                                                                 
ResourceId        :                                                                                                     
Version           : 1.19071.866.0                                                                                       
PackageFullName   : Microsoft.YourPhone_1.19071.866.0_x64__8wekyb3d8bbwe                                                
InstallLocation   : C:\Program Files\WindowsApps\Microsoft.YourPhone_1.19071.866.0_x64__8wekyb3d8bbwe                   
IsFramework       : False                                                                                               
PackageFamilyName : Microsoft.YourPhone_8wekyb3d8bbwe                                                                   
PublisherId       : 8wekyb3d8bbwe                                                                                       
IsResourcePackage : False                                                                                               
IsBundle          : False                                                                                               
IsDevelopmentMode : False                                                                                               
NonRemovable      : False                                                                                               
Dependencies      : {Microsoft.VCLibs.140.00_14.0.27323.0_x64__8wekyb3d8bbwe, Microsoft.YourPhone_1.19071.866.0_neutral_split.language-nl_8wekyb3d8bbwe, Microsoft.YourPhone_1.19071.866.0_neutral_split.scale-100_8wekyb3d8bbwe, Microsoft.YourPhone_1.19071.866.0_neutral_split.scale-150_8wekyb3d8bbwe}                    
IsPartiallyStaged : False                                                                                               
SignatureKind     : Store                                                                                               
Status            : Ok                        
```

Adding it to the list seems to be enough. More info can be found here: https://www.techspot.com/news/80245-microsoft-phone-app-windows-10-can-no-longer.html