### PR TITLE
Remove unexistant services

### DIFF
--- a/scripts/disable-services.ps1
+++ b/scripts/disable-services.ps1
@@ -6,8 +6,6 @@ $services = @(
     "diagnosticshub.standardcollector.service" # Microsoft (R) Diagnostics Hub Standard Collector Service
     "DiagTrack"                                # Diagnostics Tracking Service
     "dmwappushservice"                         # WAP Push Message Routing Service (see known issues)
-    "HomeGroupListener"                        # HomeGroup Listener
-    "HomeGroupProvider"                        # HomeGroup Provider
     "lfsvc"                                    # Geolocation Service
     "MapsBroker"                               # Downloaded Maps Manager
     "NetTcpPortSharing"                        # Net.Tcp Port Sharing Service


### PR DESCRIPTION
[HomeGroup Provider](http://batcmd.com/windows/10/services/homegroupprovider/) and [HomeGroup Listener](http://batcmd.com/windows/10/services/homegrouplistener/) does not exists since Windows 10 1803