### PR TITLE
Removed Microsoft.OneConnect duplicate

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -28,7 +28,6 @@ $apps = @(
     "Microsoft.MinecraftUWP"
     "Microsoft.NetworkSpeedTest"
     "Microsoft.Office.OneNote"
-    #"Microsoft.OneConnect"
     "Microsoft.People"
     "Microsoft.Print3D"
     "Microsoft.SkypeApp"


### PR DESCRIPTION
"Microsoft.OneConnect" was commented out in the main section, but got automatically removed in the "Threshold 2" section anyway. It's therefore a duplicate and has now been removed.