### PR TITLE
Registry tweaks to lower RAM usage

### DIFF
--- a/utils/disable-edge-prelaunch.reg
+++ b/utils/disable-edge-prelaunch.reg
@@ -1,0 +1,8 @@
+Windows Registry Editor Version 5.00
+
+; disable prelaunch. lowers ram usage slightly
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftEdge\Main]
+"AllowPrelaunch"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftEdge\TabPreloader]
+"AllowTabPreloading"=dword:00000000

--- a/utils/lower-ram-usage.reg
+++ b/utils/lower-ram-usage.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+; lowers ram usage and process count by a lot
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control]
+"SvcHostSplitThresholdInKB"=dword:04000000


### PR DESCRIPTION
disable-edge-prelaunch.reg should slightly lower RAM usage before manually launching Edge and after closing Edge.
lower-ram-usage.reg should decently reduce idle and load RAM usage.