### PR TITLE
Update remove-default-apps.ps1

### DIFF
--- a/scripts/remove-default-apps.ps1
+++ b/scripts/remove-default-apps.ps1
@@ -132,13 +132,14 @@ $apps = @(
     "Microsoft.Advertising.Xaml"
 )
 
+$appxprovisionedpackage = Get-AppxProvisionedPackage -Online
+
 foreach ($app in $apps) {
     Write-Output "Trying to remove $app"
 
     Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage -AllUsers
 
-    Get-AppXProvisionedPackage -Online |
-        Where-Object DisplayName -EQ $app |
+    ($appxprovisionedpackage).Where( {$_.DisplayName -EQ $app}) |
         Remove-AppxProvisionedPackage -Online
 }
 


### PR DESCRIPTION
Move get-appxprovisionedpackage outside loop so that it only needs to be run once, instead of once for every app. Switch Where-Object clause to .Where() to improve performance.